### PR TITLE
Ajout d'une phase de Lint dans la CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,28 @@
+name: Lint
+
+on: [push]
+
+concurrency:
+  cancel-in-progress: true
+  group: lint-${{ github.ref }}
+
+jobs:
+  code:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: "16"
+          cache: "npm"
+      - name: Install dependencies
+        run: |
+          npm install
+      - name: Lint (eslint)
+        run: |
+          npm run lint
+      - name: Lint (prettier)
+        run: |
+          npm run prettier:check

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,9 @@
         "eslint-config-prettier": "^8.3.0",
         "eslint-plugin-prettier": "^4.0.0",
         "prettier": "^2.5.1"
+      },
+      "engines": {
+        "node": "^16"
       }
     },
     "node_modules/@eslint/eslintrc": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,8 @@
 {
   "name": "aides-jeunes-stats-recorder",
+  "engines": {
+    "node": "^16"
+  },
   "version": "1.0.0",
   "description": "",
   "main": "server.js",


### PR DESCRIPTION
Cette PR :
- Explicite les version de node utilisé dans Scalingo (on avait version 16 car rien de specifié cf [ici](https://doc.scalingo.com/languages/nodejs/start#specifying-a-nodejs-version))
- Ajoute une phase de lint dans la CI