### PR TITLE
Create dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: saturday


### PR DESCRIPTION
On peut mettre en place une config `dependabot.yml`, là j'ai fait le choix (_à discuter_) de lancer Dependabot le samedi, et qu'il ne propose jamais plus de 5 PR en simultané.  

La raison du samedi, c'est de ne pas être perturbé dans la semaine par des PRs en plus et de pouvoir en discuter le lundi. 

Les dépendances urgentes liées à la sécurité pourront quand même venir dans la semaine d'après leur doc.