### PR TITLE
Fix Open Handle in tests

### DIFF
--- a/models/benefitsRecords.model.js
+++ b/models/benefitsRecords.model.js
@@ -60,8 +60,8 @@ module.exports = {
       },
     ])
   },
-  getBenefitsRankingStatistics() {
-    return BenefitsRecordsSchema.aggregate([
+  async getBenefitsRankingStatistics() {
+    return await BenefitsRecordsSchema.aggregate([
       {
         $match: {
           version: 2,


### PR DESCRIPTION
Ticket Trello : https://trello.com/c/lIknINIx/1253-sur-stats-recorder-un-test-ne-sex%C3%A9cute-pas-correctement

Actuellement c'est une piste, après ce changement on a plus de soucis d'openHandle si on a le flag `--detectOpenHandle` mais il persiste quand on l'a pas. 

Il est possible que ça cache la poussière sous le tapis sans vraiment résoudre le problème 