### PR TITLE
feat: add `teleservicePrefill`

### DIFF
--- a/schemas/benefitsRecords.mongoose.js
+++ b/schemas/benefitsRecords.mongoose.js
@@ -23,6 +23,7 @@ const BenefitsRecordsSchema = new mongoose.Schema(
         "show-unexpected-amount-link",
         "close",
         "teleservice",
+        "teleservicePrefill",
         "retour-logement",
         "simulation-caf",
         "email",


### PR DESCRIPTION
Edit: dans le doute commençont a mettre ça en prod pour acquérir la data
Ticket: https://trello.com/c/i9fwJ2kY/1494-prendre-en-compte-les-teleserviceprefill-dans-les-stats

Pour le moment les event `teleservicePrefill` ne sont pas stockés.. 
Il faudra aussi le rajouter [ici](https://github.com/betagouv/mes-aides-analytics/blob/90ac1625c93ffbb40cd1cd256f4cd3c6baccb6fd/services/config.js#L72) dans `mes-aides-analytics`

Je me pose vraiment la question de si ça nous sert vraiment de vérifier a bien l'event_type dans la liste. Ça nous fait faire deux PR a chaque fois qu'on ajoute un `event_type`. 

Dans le doute j'ai rajouté mais je serais chaud pour enlever cette validation. 